### PR TITLE
When using expval, rescaling twice

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -9,13 +9,13 @@ struct EPFields{T<:AbstractFloat}
     siteflagvar::BitArray{1}
 end
 
-function EPFields(N::Int,expval,scalefact)
+function EPFields(N::Int,expval, T)
     
     siteflagvar = trues(N)
     siteflagave = trues(N)
     
-    expave, expvar = parseexpval!(expval,siteflagave,siteflagvar,scalefact)
-    T = typeof(scalefact)
+    expave, expvar = parseexpval!(expval,siteflagave,siteflagvar)
+    
     av = zeros(T,N)
     var = zeros(T,N)
 
@@ -36,7 +36,7 @@ function EPFields(N::Int,expval,scalefact)
              siteflagvar)
 end
 
-EPFields(N::Int,expval::Nothing,scalefact,T)=EPFields(zeros(T,N),
+EPFields(N::Int,expval::Nothing,T)=EPFields(zeros(T,N),
                                                       zeros(T,N),
                                                       zeros(T,N),
                                                       ones(T,N),


### PR DESCRIPTION
Hi, I was using your package and I found a little bug. 
When using the function MetabolicEP with a set of fixed-parameter for the posterior (kward expval) the parameters are rescaled two times, one in `prepareinput` and another time in `scaleepfield`, normally the bug is unnoticed because the parameters are initialized in zero. I just eliminate the first scaling (file ep.j , line 341) and changed a few other related thinks.

Thanks a lot