### PR TITLE
Fix scaling Bug

### DIFF
--- a/src/ep.jl
+++ b/src/ep.jl
@@ -89,7 +89,7 @@ function prepareinput(K,Y,lb,ub,beta,verbose,solution,expval)
 
     scalefact = max(maximum(abs.(lb)), maximum(abs.(ub)))
     if solution === nothing
-        epfield = EPFields(N,expval,scalefact)
+        epfield = EPFields(N,expval, eltype(lb))
     else
         epfield = deepcopy(solution.sol) # preserve the original solution!
     end
@@ -334,19 +334,8 @@ function compute_mom5d(xinf, xsup)
 end
 
 
-function parseexpval!(expval,siteflagave::BitArray{1}, siteflagvar::BitArray{1},scalefact::Float64)
-
-    expave,expvar=_parseexpval!(expval,siteflagave,siteflagvar)
-
-    for (k,v) in expave
-        expave[k] = v/scalefact
-    end
-
-    for (k,v) in expvar
-        expvar[k] = v/scalefact^2
-    end
-    expave,expvar
-end
+parseexpval!(expval, siteflagave::BitArray{1}, siteflagvar::BitArray{1}) =
+    _parseexpval!(expval, siteflagave, siteflagvar)
 
 function _parseexpval!(expval::Tuple,siteflagave::BitArray{1},siteflagvar::BitArray{1})
 
@@ -368,14 +357,14 @@ function _parseexpval!(expval::Tuple,siteflagave::BitArray{1},siteflagvar::BitAr
     expave,expvar
 end
 
-function _parseexpval!(expval::Vector,siteflagave::BitArray{1},siteflagvar::BitArray{1})
+function _parseexpval!(expval::Vector, siteflagave::BitArray{1}, siteflagvar::BitArray{1})
 
     N = length(siteflagave)
     expave = Dict{Int,Float64}()
     expvar = Dict{Int,Float64}()
     for i in eachindex(expval)
         expsite = expval[i][3]
-        1 <= expsite <= N || error("expsite = $minsite not ∈ 1,...,$N")
+        1 <= expsite <= N || error("expsite = $expsite not ∈ 1,...,$N")
         if expval[i][1] != nothing
             siteflagave[expsite] = false
             expave[expsite] = expval[i][1]

--- a/src/types.jl
+++ b/src/types.jl
@@ -9,13 +9,12 @@ struct EPFields{T<:AbstractFloat}
     siteflagvar::BitArray{1}
 end
 
-function EPFields(N::Int,expval,scalefact)
+function EPFields(N::Int,expval,T)
     
     siteflagvar = trues(N)
     siteflagave = trues(N)
     
-    expave, expvar = parseexpval!(expval,siteflagave,siteflagvar,scalefact)
-    T = typeof(scalefact)
+    expave, expvar = parseexpval!(expval,siteflagave,siteflagvar)
     av = zeros(T,N)
     var = zeros(T,N)
 


### PR DESCRIPTION
Hi, I was working with your package and I found a little bug!
The problem is that the priors mean and variance is scale twice. The bug is unnoticed must of the time because those parameters are initialized in zero, but if you use the ``expval`` keyword to fix those values you have a problem. I tracked the issue and found the method ``parseexpval!`` scale the values once, and the method ``scaleepfield!``does it again! I just deleted the scaling in the first one.

Thanks for the great package