### PR TITLE
Update Readme.md to new julia Pkg-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ Julia Version
 
 Installing the package
 
-``julia> Pkg.clone("https://github.com/anna-pa-m/Metabolic-EP/","MetabolicEP.jl")``.
+
+```julia> using Pkg
+   julia> pkg"add https://github.com/anna-pa-m/Metabolic-EP/","MetabolicEP.jl"
+```
 
 Otherwise, if you do not want to use the package manager, from a local copy of  the directory ``src`` in this repository, you can
 ``julia> include("dirtosource/src/MetabolicEP.jl"); using MetabolicEP``


### PR DESCRIPTION
I noticed while installing, that pkg.clone does has been deprecated and does not work anymore. 
I thought I might add this small fix for newcomers to Julia.