### PR TITLE
Linear programming uses packages up to date

### DIFF
--- a/src/HitAndRun.jl
+++ b/src/HitAndRun.jl
@@ -1,6 +1,9 @@
 module HitAndRun
-using LinearAlgebra, Clp, MathProgBase
-export hrsample
+using LinearAlgebra
+using SparseArrays, JuMP, GLPK
+export hrsample, warmup
+include("utils.jl")
+
 function hrsample(S, b, lb, ub; niter=10^6, nsamples = 10000)
     x = warmup(S,b,lb,ub);
     m,n = size(S)
@@ -34,10 +37,10 @@ function warmup(S, b, lb, ub)
     ei = zeros(n)
     for i=1:n
         ei[i] = -1.0
-        sol=linprog(ei, S, b, b, lb, ub, ClpSolver())
+        sol=linprog(ei, S, fill('=', length(b)), b, lb, ub, GLPK.Optimizer)
         x0 .+= sol.sol / 2n
         ei[i] = +1.0
-        sol=linprog(ei, S, b, b, lb, ub, ClpSolver())
+        sol=linprog(ei, S, fill('=', length(b)), b, lb, ub, GLPK.Optimizer)
         ei[i] = 0.0
         x0 .+= sol.sol / 2n
     end

--- a/src/HitAndRun.jl
+++ b/src/HitAndRun.jl
@@ -1,7 +1,7 @@
 module HitAndRun
 using LinearAlgebra
 using SparseArrays, JuMP, GLPK
-export hrsample, warmup
+export hrsample
 include("utils.jl")
 
 function hrsample(S, b, lb, ub; niter=10^6, nsamples = 10000)

--- a/src/MetabolicEP.jl
+++ b/src/MetabolicEP.jl
@@ -3,7 +3,7 @@ module MetabolicEP
 using MAT, ExtractMacro, SpecialFunctions, SparseArrays, Printf
 using SparseArrays: SparseMatrixCSC
 using Printf: @printf
-using Clp, MathProgBase
+using JuMP, GLPK
 
 include("HitAndRun.jl")
 using .HitAndRun # internal module


### PR DESCRIPTION
Function `linprog` was relying on packages `Clp`, `MathProgBase` which are now (Julia v1.6) obsolete.
Replaced with `JuMP`, `GLPK` following [this](https://jump.dev/MathOptInterface.jl/stable/tutorials/mathprogbase/#linprog)